### PR TITLE
Fix baseurl of jekyll configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ lang: "en"
 paginate: 5
 
 url: "https://metasys-server.github.io/api-landing"
-baseurl: "/metasys-server-api-landing/"
+baseurl: "/api-landing/"
 remote_theme: ConnorChristie/jekyll-theme-prettydocs
 pre_release: false
 


### PR DESCRIPTION
The baseurl was still referencing the old repo name.
During the move I shortened the name of the repo from
metasys-server-api-landing to api-landing since
metyas-server is the org name.