### PR TITLE
Fix version dropdown and add pre-release support

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,10 +6,10 @@ force-https: True
 lang: "en"
 paginate: 5
 
-url: "https://metasys-server.github.io/api-landing"
+url: "https://github.jci.com/pages/jchrisco/api-landing"
 baseurl: "/api-landing/"
 remote_theme: metasys-server/jekyll-theme-prettydocs
-pre_release: false
+pre_release: true
 
 # TODO: Local - Comment out before publishing
 # url: "http://127.0.0.1:8080"

--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ lang: "en"
 paginate: 5
 
 url: "https://github.jci.com/pages/jchrisco/api-landing"
-baseurl: "/api-landing/"
+baseurl: "/pages/jchrisco/api-landing/"
 remote_theme: metasys-server/jekyll-theme-prettydocs
 pre_release: true
 

--- a/_config.yml
+++ b/_config.yml
@@ -6,8 +6,8 @@ force-https: True
 lang: "en"
 paginate: 5
 
-url: "https://github.jci.com/pages/jchrisco/api-landing"
-baseurl: "/pages/jchrisco/api-landing/"
+url: "https://connorchristie.github.io/metasys-server-api-landing"
+baseurl: "/metasys-server-api-landing/"
 remote_theme: metasys-server/jekyll-theme-prettydocs
 pre_release: true
 

--- a/_config.yml
+++ b/_config.yml
@@ -6,10 +6,10 @@ force-https: True
 lang: "en"
 paginate: 5
 
-url: "https://connorchristie.github.io/metasys-server-api-landing"
-baseurl: "/metasys-server-api-landing/"
+url: "https://metasys-server.github.io/api-landing"
+baseurl: "/api-landing/"
 remote_theme: metasys-server/jekyll-theme-prettydocs
-pre_release: true
+pre_release: false
 
 # TODO: Local - Comment out before publishing
 # url: "http://127.0.0.1:8080"

--- a/_data/default/api.yml
+++ b/_data/default/api.yml
@@ -1,2 +1,4 @@
+- name: '<i class="metasys"></i> API v2 (latest)'
+  url: 'api/v2'
 - name: '<i class="metasys"></i> API v1'
   url: 'api/v1'

--- a/_data/default/cards.yml
+++ b/_data/default/cards.yml
@@ -11,7 +11,7 @@
       intro: 'Browse the documentation of our REST API'
       color: 'blue'
       icon:  'fa fa-file-alt'
-      url: 'api/v1/'
+      url: 'api/v2/'
 
     - title: 'FAQs'
       intro: 'See what problems others might be having'

--- a/api/index.markdown
+++ b/api/index.markdown
@@ -10,3 +10,23 @@ color: blue
 {% for version in site.data.default.api %}
 - [{{ version.name }}]({{ version.url | prepend: site.baseurl }})
 {% endfor %}
+
+{% if site.pre_release %}
+
+## Preview Versions
+
+These versions are only hosted internally and are shown when a build in TeamCity is pinned. The list of pinned builds are then shown here with their respective build number and branch name.
+
+<div class="version-container-pinned" markdown="1">
+{:#version-link-template}
+[~name~]({{ '/api/pre-release/?build=~buildId~' | relative_url }})
+</div>
+
+## PR Builds
+
+<div class="version-container-pr" markdown="1">
+{:#version-link-template}
+[~name~]({{ '/api/pre-release/?build=~buildId~' | relative_url }})
+</div>
+
+{% endif %}

--- a/api/pre-release.html
+++ b/api/pre-release.html
@@ -1,0 +1,28 @@
+---
+page_title: Pre-Release
+permalink: /api/pre-release/
+layout: default
+color: red
+layout_small: true
+---
+
+<style>
+  html, body {
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+  }
+
+  .page-wrapper {
+    min-height: 0;
+    margin-bottom: 0;
+  }
+
+  .page-wrapper:after {
+    height: 0;
+  }
+
+  iframe {
+    border: none;
+  }
+</style>

--- a/api/v2.html
+++ b/api/v2.html
@@ -1,0 +1,35 @@
+---
+title: Metasys API v2
+permalink: /api/v2/
+layout: default
+color: blue
+layout_small: true
+---
+
+<script src="https://api.apiary.io/seeds/embed.js"></script>
+<script>
+  var embed = new Apiary.Embed({
+    subdomain: "metasysapiando",
+    header: ".page-wrapper",
+    preferences: {
+      permalinks: true,
+      displayHttpMethods: true
+    }
+  });
+</script>
+
+<style>
+  html, body {
+    margin: 0;
+    padding: 0;
+  }
+
+  .page-wrapper {
+    min-height: 0;
+    margin-bottom: 0;
+  }
+
+  .page-wrapper:after {
+    height: 0;
+  }
+</style>

--- a/assets/css/partials/_header.scss
+++ b/assets/css/partials/_header.scss
@@ -21,12 +21,12 @@
     .dropdown-toggle {
       background-color: Transparent;
       border: none;
-      color: #fff;
+      color: rgb(0, 0, 0);
       text-decoration: none;
       font-size: 13pt;
 
       &:hover {
-        color: rgba(255,255,255,.7);
+        color: rgba(0, 0, 0,.7);
       }
     }
   }

--- a/assets/js/pre-releases.js
+++ b/assets/js/pre-releases.js
@@ -2,12 +2,12 @@ function getBuildDetails(buildId, cb) {
   $.getJSON(tc_url + '/guestAuth/app/rest/builds/id:' + buildId, cb);
 }
 
-function createVersionLink(version, date, isLatest, buildId) {
-  const container = $('#version-link-template').clone().attr('id', null);
+function createVersionLink(container, version, date, isLatest, buildId) {
   const content = container.html()
     .replace('~name~', version + ' &mdash; ' + moment(date, 'YYYYMMDDTHHmmssZ').format('MMM D, YYYY h:mmA') + (isLatest ? ' (latest)' : ''))
     .replace('~buildId~', buildId);
 
+  container.attr('id', null);
   return container.html(content).css('display', 'block');
 }
 
@@ -20,36 +20,50 @@ if (enable_prerelease) {
   const buildType = 'MetasysG4_CoreServer_ApiDocumentation_Pr';
 
   $(document).ready(function() {
-    const isDetailsPage = window.location.pathname.indexOf('/api/pre-release/version') !== -1;
-    const isListingPage = window.location.pathname.indexOf('/api/pre-release') !== -1 && !isDetailsPage;
+    const path = window.location.pathname;
+    const isDetailsPage = path.endsWith('/api/pre-release') || path.endsWith('/api/pre-release/');
+    const isListingPage = (path.endsWith('/api') || path.endsWith('/api/')) && !isDetailsPage;
 
-    $.getJSON(tc_url + '/guestAuth/app/rest/builds/?locator=buildType:' + buildType + ',status:SUCCESS,pinned:true,branch:(default:any)', function (data) {
-      const dropdown = $('#version-dropdown')
-        .prepend($('<li class="dropdown-header">Public Versions</li>'))
-        .append($('<li class="dropdown-header">Pre-release Versions</li>'));
+    if (isListingPage) {
+      $.getJSON(tc_url + '/guestAuth/app/rest/builds/?locator=buildType:' + buildType + ',status:SUCCESS,pinned:true,branch:(default:any)', function (data) {
+        let isFirst = true;
 
-      let isFirst = true;
+        data.build.sort((a, b) => b.id - a.id).forEach(build => {
+          const name = build.branchName + '-' + build.number;
+          const id = build.id;
 
-      data.build.forEach(build => {
-        const name = build.branchName + '-' + build.number;
-        const id = build.id;
-
-        dropdown.append($('<li><a href="' + baseurl + 'api/pre-release/version/?build=' + id + '">' + name + '</a></li>'));
-
-        if (isListingPage) {
           const isLatest = isFirst;
-          getBuildDetails(id, details => {
-            createVersionLink(name, details.finishDate, isLatest, id).appendTo($('.version-container'));
-          });
-        }
+          const container = $('#version-link-template').clone();
+          container.appendTo($('.version-container-pinned'));
 
-        isFirst = false;
+          getBuildDetails(id, details => {
+            createVersionLink(container, name, details.finishDate, isLatest, id)
+          });
+
+          isFirst = false;
+        });
       });
-    });
+
+      $.getJSON(tc_url + '/guestAuth/app/rest/builds/?locator=buildType:' + buildType + ',status:SUCCESS,pinned:false,branch:(default:any)', function (data) {
+        data.build.sort((a, b) => b.id - a.id).forEach(build => {
+          const name = build.branchName + '-' + build.number;
+          const id = build.id;
+
+          const container = $('#version-link-template').clone();
+          container.appendTo($('.version-container-pr'));
+
+          getBuildDetails(id, details => {
+            createVersionLink(container, name, details.finishDate, false, id);
+          });
+
+          isFirst = false;
+        });
+      });
+    }
 
     if (isDetailsPage) {
       const buildId = window.location.search.replace('?build=', '');
-      const previewUrl = tc_url + '/repository/download/' + buildType + '/' + buildId + ':id/metasys-api.zip%21/previews/index.html';
+      const previewUrl = tc_url + '/guestAuth/repository/download/' + buildType + '/' + buildId + ':id/metasys-api.zip%21/previews/index.html';
       const frame = $('<iframe src="' + previewUrl + '"></iframe>');
 
       $('body').append(frame);


### PR DESCRIPTION
This fixes the version dropdown styling (so it's visible again) and adds the v2 link to the dropdown. Version 2 has also been changed to be the default version selected after clicking "Rest API".

Here is what the changes look like: https://29-148663593-gh.circle-artifacts.com/0/site-preview/index.html