### PR TITLE
docs: remove 'latest' label from v3

### DIFF
--- a/_data/default/api.yml
+++ b/_data/default/api.yml
@@ -1,4 +1,4 @@
-- name: '<i class="metasys"></i> API v3 (latest)'
+- name: '<i class="metasys"></i> API v3'
   url: 'api/v3'
 - name: '<i class="metasys"></i> API v2'
   url: 'api/v2'


### PR DESCRIPTION
In preparation for publishing v4 it's time to remove the
"latest" label from v3. This label is currently seen in the
API Versions drop down list at a page list this:
https://metasys-server.github.io/api-landing/api/v3/

cc: @musicfuel @hicksjacobp @matttrawicki 