### PR TITLE
docs: add version support matrix

### DIFF
--- a/_data/default/cards.yml
+++ b/_data/default/cards.yml
@@ -19,6 +19,12 @@
       icon:  'fa fa-file-alt'
       url: 'api/v3/'
 
+    - title: 'Version Support Matrix'
+      intro: See which versions of the REST API are available for your release of Metasys.
+      color: 'green'
+      icon: 'fa fa-life-ring'
+      url: 'guides/version-support-matrix/'
+
     # - title: 'FAQs'
     #   intro: 'See what problems others might be having with <i class="metasys"></i> API v1 (Release 10.0).'
     #   color: 'orange'

--- a/guides/index.markdown
+++ b/guides/index.markdown
@@ -9,4 +9,5 @@ date: 2018-08-10
 
 # Guides
 
-- [Quickstart]({{ '/guides/quickstart/' | relative_url }})
+<!-- - [Quickstart]({{ '/guides/quickstart/' | relative_url }}) -->
+- [Version Support Matrix]({{ '/guides/version-support-matrix/' | relative_url }})

--- a/guides/version-support-matrix.markdown
+++ b/guides/version-support-matrix.markdown
@@ -1,0 +1,23 @@
+---
+title: "Version Support Matrix"
+permalink: /guides/version-support-matrix/
+group: versions
+layout: post
+color: green
+icon: far fa-paper-plane
+---
+
+The following table shows which versions of the REST API are available for each release of Metasys.
+
+| API Version | Metasys 10.0 | Metasys 10.1 | Metasys 11.0 | Metasys 12.0 |
+| ----------- | :----------: | :----------: | :----------: | :----------: |
+| v1          |      ✅       |      ❌       |      ❌       |      ❌       |
+| v2          |      ❌       |      ✅       |      ✅       |      ✓       |
+| v3          |      ❌       |      ❌       |      ✅       |      ✓       |
+| v4          |      ❌       |      ❌       |      ❌       |      ✅       |
+
+**Legend**
+
+* ❌ - Not available
+* ✅ - Supported
+* ✓ - Deprecated (supported, but may be removed in a future release)

--- a/guides/version-support-matrix.markdown
+++ b/guides/version-support-matrix.markdown
@@ -9,15 +9,15 @@ icon: far fa-paper-plane
 
 The following table shows which versions of the REST API are available for each release of Metasys.
 
-| API Version | Metasys 10.0 | Metasys 10.1 | Metasys 11.0 | Metasys 12.0 |
-| ----------- | :----------: | :----------: | :----------: | :----------: |
-| v1          |      ✅       |      ❌       |      ❌       |      ❌       |
-| v2          |      ❌       |      ✅       |      ✅       |      ✓       |
-| v3          |      ❌       |      ❌       |      ✅       |      ✓       |
-| v4          |      ❌       |      ❌       |      ❌       |      ✅       |
+| API Version |            Metasys 10.0            |            Metasys 10.1            |            Metasys 11.0            |            Metasys 12.0            |
+| ----------- | :--------------------------------: | :--------------------------------: | :--------------------------------: | :--------------------------------: |
+| v1          | <i class='fa fa-check-circle'></i> |    <i class='fa fa-times'></i>     |    <i class='fa fa-times'></i>     |    <i class='fa fa-times'></i>     |
+| v2          |    <i class='fa fa-times'></i>     | <i class='fa fa-check-circle'></i> | <i class='fa fa-check-circle'></i> |    <i class='fa fa-check'></i>     |
+| v3          |    <i class='fa fa-times'></i>     |    <i class='fa fa-times'></i>     | <i class='fa fa-check-circle'></i> |    <i class='fa fa-check'></i>     |
+| v4          |    <i class='fa fa-times'></i>     |    <i class='fa fa-times'></i>     |    <i class='fa fa-times'></i>     | <i class='fa fa-check-circle'></i> |
 
 **Legend**
 
-* ❌ - Not available
-* ✅ - Supported
-* ✓ - Deprecated (supported, but may be removed in a future release)
+* <i class='fa fa-times'></i> - Not available
+* <i class='fa fa-check-circle'></i> - Supported
+* <i class='fa fa-check'></i> - Deprecated (supported, but may be removed in a future release)

--- a/guides/version-support-matrix.markdown
+++ b/guides/version-support-matrix.markdown
@@ -11,13 +11,18 @@ The following table shows which versions of the REST API are available for each 
 
 | API Version |            Metasys 10.0            |            Metasys 10.1            |            Metasys 11.0            |            Metasys 12.0            |
 | ----------- | :--------------------------------: | :--------------------------------: | :--------------------------------: | :--------------------------------: |
-| v1          | <i class='fa fa-check-circle'></i> |    <i class='fa fa-times'></i>     |    <i class='fa fa-times'></i>     |    <i class='fa fa-times'></i>     |
-| v2          |    <i class='fa fa-times'></i>     | <i class='fa fa-check-circle'></i> | <i class='fa fa-check-circle'></i> |    <i class='fa fa-check'></i>     |
-| v3          |    <i class='fa fa-times'></i>     |    <i class='fa fa-times'></i>     | <i class='fa fa-check-circle'></i> |    <i class='fa fa-check'></i>     |
-| v4          |    <i class='fa fa-times'></i>     |    <i class='fa fa-times'></i>     |    <i class='fa fa-times'></i>     | <i class='fa fa-check-circle'></i> |
+| [v1][]      | <i class='fa fa-check-circle'></i> |    <i class='fa fa-times'></i>     |    <i class='fa fa-times'></i>     |    <i class='fa fa-times'></i>     |
+| [v2][]      |    <i class='fa fa-times'></i>     | <i class='fa fa-check-circle'></i> | <i class='fa fa-check-circle'></i> |    <i class='fa fa-check'></i>     |
+| [v3][]      |    <i class='fa fa-times'></i>     |    <i class='fa fa-times'></i>     | <i class='fa fa-check-circle'></i> |    <i class='fa fa-check'></i>     |
+| [v4][]      |    <i class='fa fa-times'></i>     |    <i class='fa fa-times'></i>     |    <i class='fa fa-times'></i>     | <i class='fa fa-check-circle'></i> |
 
 **Legend**
 
 * <i class='fa fa-times'></i> - Not available
 * <i class='fa fa-check-circle'></i> - Supported
 * <i class='fa fa-check'></i> - Deprecated (supported, but may be removed in a future release)
+
+[v1]: /api/v1/
+[v2]: /api/v2/
+[v3]: /api/v3/
+[v4]: /api/v4


### PR DESCRIPTION
This is the rendered page:

<img width="1316" alt="image" src="https://user-images.githubusercontent.com/826112/172191981-ea9b0351-9079-4a7b-8cda-57ed7303939e.png">

It's a little ugly but gets the job done.

cc: @musicfuel @hicksjacobp 

Also some redundancy between the page header and the table header 

This is what it looks like if I remove the "table" header:

<img width="1228" alt="image" src="https://user-images.githubusercontent.com/826112/172194568-4658d509-4123-417c-974d-d6f57b82fa1e.png">

Here's the look with some font-awesome icons


<img width="1203" alt="image" src="https://user-images.githubusercontent.com/826112/172233217-de221f9d-d4a9-49a8-828a-3373d876e144.png">

And finally with links from version numbers to specs:


<img width="1260" alt="image" src="https://user-images.githubusercontent.com/826112/172234239-db2d96a3-e3cd-42e5-86f1-c2805bee3e4f.png">
