### PR TITLE
fix redirect for v4 api

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,10 @@ jobs:
                   if (urlParts.length < 2) return;
 
                   const last = urlParts[urlParts.length - 1];
+                  if (last == 'v4') {
+                    e.originalEvent.currentTarget.href = current + ".html";
+                    return;
+                  }
                   if (last === '' || last.indexOf('.') === -1) {
                       e.originalEvent.currentTarget.href = current + (last === '' ? '' : '/') + 'index.html';
                   }


### PR DESCRIPTION
Most of the pages when rendered are in their own folder in a page labeled index.html

So the redirect takes a request for `/v3` and turns it into `/v3/index.html`. But for whatever reason `v4` just gets copied over as v4.html. So the redirect just needs to tack on .html