### PR TITLE
bug: correct the index redirects

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
                       e.originalEvent.currentTarget.href = current + (last === '' ? '' : '/') + 'index.html';
                   }
               });
-              EOT
+            EOT
 
       - store_artifacts:
           path: ~/repo/_site


### PR DESCRIPTION
The `cat` command is being used to add a click handler for <a> tags on the page. It's using an EOT delimiter to do this, but the closing delimiter was not in the correct column so it was not recognized as a delimiter. Instead the end of file was used as a delimiter, and the EOT remained in the source file.

This caused a warning but didn't prvent the functionality from working.

This cleans it up anyway.