### PR TITLE
feat: post updates to the PR during and after build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,15 @@ jobs:
     working_directory: ~/repo
 
     steps:
+      # Check to see if it's a pull request and if not exit
+      # We have a separate GitHub workflow to retrigger this on a pull request
+      - run:
+          name: Check for PR or master
+          command: |
+            if [ -z "$CIRCLE_PULL_REQUEST" ]; then
+              echo "Not a PR"
+              circleci step halt
+            fi
       - checkout
       - run:
           name: Pull submodules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,12 @@ jobs:
           - v1-dependencies-
 
       - run:
+          name: Post Preview Build Url
+          command: |
+            sudo apt-get install jq
+            .circleci/post-comment-pending.sh $GH_USER $GH_TOKEN metasys-server api-landing ${CIRCLE_PULL_REQUEST##*/} $CIRCLE_WORKFLOW_ID
+
+      - run:
           name: Install dependencies
           command: |
             bundle install --jobs=4 --retry=3 --path vendor/bundle
@@ -75,3 +81,12 @@ jobs:
       - store_artifacts:
           path: ~/repo/_site
           destination: site-preview
+
+      - run:
+          name: Post Preview URL to GitHub PR
+          command: |
+            sudo apt-get install jq
+            .circleci/post-comment.sh $GH_USER $GH_TOKEN metasys-server api-landing ${CIRCLE_PULL_REQUEST##*/} $CIRCLE_WORKFLOW_JOB_ID
+
+
+

--- a/.circleci/post-comment-pending.sh
+++ b/.circleci/post-comment-pending.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Purpose:
+# Checks to see if there already exists a comment on the PR that starts with Circle CI Preview.
+#   - If it does exist, then it's updated to say "Circle CI Preview currently being generated"
+#   - If it does not exist, then a new comment is created that says that.
+
+
+set -x
+USER=$1
+TOKEN=$2
+ORG=$3
+REPO=$4
+PR=$5
+WORKFLOW_ID=$6
+
+# Notes on the jq
+# .[] - Iterate thru the array
+# select(.body | contains()) - Select an object if it has a body that contains "Circle CI Preview Available"
+# This streams 0 or more objects but not witin an array. The next step will turn it back into an array
+
+# jq -r -s - This invocation of jq uses -s which "slurps" in the stream turning it back into an array
+#            The -r says to output raw strings, so if we find a url it'll not have double quotes around it
+# first - This says grab the first element of the array (if there is one)
+# .url  - This says grab the url from the object (if there is one)
+# The output of this if there is no matching element is the raw string null (not an actual null value which is confusing)
+
+# preview_comment_url=$(curl --location "https://api.github.com/repos/$ORG/$REPO/issues/$PR/comments" \
+#             -u "$USER:$TOKEN" | jq  '.[] | {body: .body, url: .url} | select(.body | contains("Circle CI Preview Available"))' | jq -r -s '. | first | .url')
+preview_comment_url=$(curl --location "https://api.github.com/repos/$ORG/$REPO/issues/$PR/comments" \
+            -u "$USER:$TOKEN" | jq  '.[] | select(.body | contains("Circle CI Preview"))' | jq -r -s '. | first | .url')
+
+preview_comment="Circle CI Preview currently [being generated]($CIRCLE_BUILD_URL)"
+comment_body="{\"body\": \"$preview_comment\"}"
+
+echo $comment_body
+
+if [[ $preview_comment_url != "null" ]]
+then
+    # we have an existing comment we want to update
+    echo "Updating $preview_comment_url"
+    curl \
+    -X PATCH \
+    -H "Accept: application/vnd.github+json" \
+    -u "$USER:$TOKEN" \
+    $preview_comment_url \
+    -d "$comment_body"
+
+else
+    # we don't have an existing comment, we need to create one
+    echo "Creating new comment"
+    curl \
+    -X POST \
+    -H "Accept: application/vnd.github+json" \
+    -u "$USER:$TOKEN" \
+    https://api.github.com/repos/$ORG/$REPO/issues/$PR/comments \
+    -d "$comment_body"
+fi
+
+set +x

--- a/.circleci/post-comment.sh
+++ b/.circleci/post-comment.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Purpose:
+# Checks to see if there already exists a comment on the PR that starts with Circle CI Preview.
+#   - If it does exist, then it's updated to say "Circle CI Preview Available with link to preview"
+#   - If it does not exist, then a new comment is created that says that.
+
+set -x
+USER=$1
+TOKEN=$2
+ORG=$3
+REPO=$4
+PR=$5
+JOB_ID=$6
+
+# Notes on the jq
+# .[] - Iterate thru the array
+# select(.body | contains()) - Select an object if it has a body that contains "Circle CI Preview Available"
+# This streams 0 or more objects but not witin an array. The next step will turn it back into an array
+
+# jq -r -s - This invocation of jq uses -s which "slurps" in the stream turning it back into an array
+#            The -r says to output raw strings, so if we find a url it'll not have double quotes around it
+# first - This says grab the first element of the array (if there is one)
+# .url  - This says grab the url from the object (if there is one)
+# The output of this if there is no matching element is the raw string null (not an actual null value which is confusing)
+
+# preview_comment_url=$(curl --location "https://api.github.com/repos/$ORG/$REPO/issues/$PR/comments" \
+#             -u "$USER:$TOKEN" | jq  '.[] | {body: .body, url: .url} | select(.body | contains("Circle CI Preview Available"))' | jq -r -s '. | first | .url')
+preview_comment_url=$(curl --location "https://api.github.com/repos/$ORG/$REPO/issues/$PR/comments" \
+            -u "$USER:$TOKEN" | jq  '.[] | select(.body | contains("Circle CI Preview"))' | jq -r -s '. | first | .url')
+
+preview_comment="Circle CI Preview [Available](https://output.circle-artifacts.com/output/job/${JOB_ID}/artifacts/0/site-preview/index.html)"
+comment_body="{\"body\": \"$preview_comment\"}"
+
+echo $comment_body
+
+if [[ $preview_comment_url != "null" ]]
+then
+    # we have an existing comment we want to update
+    echo "Updating $preview_comment_url"
+    curl \
+    -X PATCH \
+    -H "Accept: application/vnd.github+json" \
+    -u "$USER:$TOKEN" \
+    $preview_comment_url \
+    -d "$comment_body"
+
+else
+    # we don't have an existing comment, we need to create one
+    echo "Creating new comment"
+    curl \
+    -X POST \
+    -H "Accept: application/vnd.github+json" \
+    -u "$USER:$TOKEN" \
+    https://api.github.com/repos/$ORG/$REPO/issues/$PR/comments \
+    -d "$comment_body"
+fi
+
+set +x


### PR DESCRIPTION
The PR will be updated with a comment
that says Circle CI Preview being generated with a link to the build. When the preview is available that comment will be updated with a link to the preview.

If the PR is updated later, the same process is repeated. First the comment is changed to say preview is being generated; and then it's updated to point to the preview.